### PR TITLE
feat: accept `string[]` as a `bot.hears` trigger

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1091,9 +1091,9 @@ export class Bot<
 	 */
 	hears<
 		Ctx = ContextType<typeof this, "message">,
-		Trigger extends RegExp | string | ((context: Ctx) => boolean) =
+		Trigger extends RegExp | MaybeArray<string> | ((context: Ctx) => boolean) =
 			| RegExp
-			| string
+			| MaybeArray<string>
 			| ((context: Ctx) => boolean),
 	>(
 		trigger: Trigger,
@@ -1103,6 +1103,7 @@ export class Bot<
 			const text = context.text ?? context.caption;
 			if (
 				(typeof trigger === "string" && text === trigger) ||
+				(Array.isArray(trigger) && text && trigger.includes(text)) ||
 				// @ts-expect-error
 				(typeof trigger === "function" && trigger(context)) ||
 				(trigger instanceof RegExp && text && trigger.test(text))

--- a/tests/types/triggers.ts
+++ b/tests/types/triggers.ts
@@ -19,6 +19,9 @@ import { Bot } from "../../src/bot.ts";
 				test: number;
 			}>();
 		})
+		.hears(["a", "b"], (context) => {
+			expectTypeOf<typeof context>().toBeObject();
+		})
 		.hears("a", (context) => {
 			expectTypeOf<typeof context>().toBeObject();
 		})


### PR DESCRIPTION
```typescript
export const bot = new Bot("...")
  .hears("hey", (ctx) => ctx.reply("Hey!"))
  .hears(["sup", "hewwo"], (ctx) => ctx.reply("haaaai!!!!"))
```